### PR TITLE
Fix `--name` option

### DIFF
--- a/getopt.bash
+++ b/getopt.bash
@@ -60,7 +60,7 @@ getopt() {
     # First parse always uses flags=p since getopt always parses its own
     # arguments effectively in this mode.
     parsed=$(_getopt_parse getopt ahl:n:o:qQs:TuV \
-      alternative,help,longoptions:,name,options:,quiet,quiet-output,shell:,test,version \
+      alternative,help,longoptions:,name:,options:,quiet,quiet-output,shell:,test,version \
       p "$@")
     status=$?
     if [[ $status != 0 ]]; then

--- a/test.bash
+++ b/test.bash
@@ -178,6 +178,11 @@ title "Quoting long arguments"
 
 test -o xy:z:: --long=abc,def:,dez:: -- -y "$(head -n 200 getopt.bash)"
 
+title "Passing custom program name with -n or --name"
+
+test -o xy:z:: --long=abc,def:,dez:: -n custom -- -y
+test -o xy:z:: --long=abc,def:,dez:: --name custom -- -y
+
 title "GETOPT_COMPATIBLE and POSIXLY_CORRECT"
 
 # Baseline reorders options before non-option params: -x -y -- foo


### PR DESCRIPTION
Previously the `--name` option did not expect an argument as it was
missing a trailing `:` in its optstring.